### PR TITLE
Provide better descriptions to commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,15 +41,19 @@
         "commands": [
             {
                 "command": "comment.makeLineComment",
-                "title": "Line to KFCS Spacer"
+                "title": "Make a KFCS Spacer Comment"
             },
             {
                 "command": "comment.makeSectionComment",
-                "title": "Line to KFCS Header"
+                "title": "Make a KFCS Header Comment"
             },
             {
                 "command": "comment.makeReverseSectionComment",
-                "title": "Line to KFCS Reverse Header"
+                "title": "Make a KFCS Reverse Header Comment"
+            },
+            {
+                "command": "comment.makeFlagComment",
+                "title": "Make a Flag Comment"
             }
         ],
         "menus": {


### PR DESCRIPTION
This PR changes commands description in order to be more clear. Moreover now they can be found searching `comment`. I've installed this package and I like it a lot but I use it very seldomly because I can't (and I don't want to) remember the shortcuts and when searching for `comment` with comment palette `cmd+shift+p` commands they do not appear.